### PR TITLE
fix: add z-index to fix date picker overlapping in mobile

### DIFF
--- a/src/components/DateControl.tsx
+++ b/src/components/DateControl.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import styled from "styled-components";
 import DatePicker from "react-datepicker";
 import { registerLocale } from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
@@ -15,6 +16,10 @@ interface ButtonProps {
 }
 
 registerLocale("enGB", enGB);
+
+export const DatePickerWrapper = styled.div`
+  z-index: 1000;
+`;
 
 // using a class component to avoid "Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?"
 class DateInputButton extends React.Component<ButtonProps> {
@@ -38,12 +43,14 @@ export class DateControl extends React.Component<Props> {
   render() {
     const { selectedDate, onDateChanged } = this.props;
     return (
-      <DatePicker
-        selected={selectedDate}
-        onChange={onDateChanged}
-        locale="enGB"
-        customInput={this.input}
-      />
+      <DatePickerWrapper>
+        <DatePicker
+          selected={selectedDate}
+          onChange={onDateChanged}
+          locale="enGB"
+          customInput={this.input}
+        />
+      </DatePickerWrapper>
     );
   }
 }


### PR DESCRIPTION
The date picker was rendering behind other elements on my phone, making it hard to toggle the months, so this PR adds a styled component with z-index to fix.

before:
<img width="532" alt="Screenshot 2024-02-23 at 8 56 55 PM" src="https://github.com/nanreh/calendar-hack/assets/21087163/8c2a4561-edac-4bd6-af38-2ecf23d9700c">


after:
<img width="542" alt="Screenshot 2024-02-23 at 8 57 26 PM" src="https://github.com/nanreh/calendar-hack/assets/21087163/abb4702d-c5da-43e0-8a8b-8f818bb7b173">




