### PR TITLE
Update planList.ts

### DIFF
--- a/src/ch/planList.ts
+++ b/src/ch/planList.ts
@@ -45,7 +45,7 @@ export const plans: PlanSummary[] = [
     "Half Marathon",
   ],
   [
-    "higdon_int_half1",
+    "higdon_int_half2",
     "Hal Higdon: Half Marathon Intermediate 2",
     "Half Marathon",
   ],


### PR DESCRIPTION
Updates the key value for Hal Higdon: Half Marathon Intermediate 2 to `higdon_int_half2`. Previously it was `higdon_int_half1` which caused a clash with Intermediate 1 and thus would not show the correct plan in the UI. 