### PR TITLE
Fix typo in frr_multiple_distances_02 plans

### DIFF
--- a/public/plans/json/frr_multiple_distances_02.json
+++ b/public/plans/json/frr_multiple_distances_02.json
@@ -115,7 +115,7 @@
                "distance": 7.0
             },
             {
-               "title": "General aerobic {9:1j}",
+               "title": "General aerobic {9:14}",
                "distance": 9.0
             },
             {

--- a/public/plans/yaml/frr_multiple_distances_02.yaml
+++ b/public/plans/yaml/frr_multiple_distances_02.yaml
@@ -69,7 +69,7 @@ schedule:
   - title: Rest or cross-training
   - title: General aerobic {7:11}
     distance: 7.0
-  - title: General aerobic {9:1j}
+  - title: General aerobic {9:14}
     distance: 9.0
   - title: Speed
     description: |-


### PR DESCRIPTION
Loading the plan currently crashes the site with error:


```
Error: invalid syntax at line 1 col 17:

1  General aerobic {9:1j}
```